### PR TITLE
Speed up positioning and culling

### DIFF
--- a/source/arroost/components/dom.js
+++ b/source/arroost/components/dom.js
@@ -44,11 +44,6 @@ export class Dom extends Component {
 		this.style = style
 		this.input = input ?? shared.scene?.input
 		this.cullBounds = this.use(cullBounds)
-
-		// this.cullBoundsToCorner = this.use(() => {
-		// 	const [x, y] = this.cullBounds.get() ?? [0, 0]
-		// 	return distanceBetween([0, 0], [x, y])
-		// }, [this.cullBounds])
 	}
 
 	getElement() {
@@ -107,15 +102,7 @@ export class Dom extends Component {
 			this.use(() => {
 				const [x, y] = this.transform.absolutePosition.get()
 
-				const bounds = shared.scene.bounds.get() ?? {
-					left: -Infinity,
-					top: -Infinity,
-					right: Infinity,
-					bottom: Infinity,
-					// center: [0, 0],
-					// centerToCorner: Infinity,
-				}
-
+				const bounds = shared.scene.bounds.get()
 				if (!this.outOfView.get()) {
 					const xPlacement = x - bounds.left
 					if (xPlacement <= 0) {
@@ -159,84 +146,6 @@ export class Dom extends Component {
 
 					this.outOfView.set(false)
 				}
-
-				// if (this.outOfView.get()) {
-				// 	const xPlacement = x - bounds.left
-				// 	if (xPlacement > 0) {
-				// 		this.outOfView.set(false)
-				// 		return
-				// 	}
-
-				// 	const yPlacement = y - bounds.top
-				// 	if (yPlacement > 0) {
-				// 		this.outOfView.set(false)
-				// 		return
-				// 	}
-
-				// 	// if (xPlacement < bounds.right) {
-				// 	// 	this.outOfView.set(false)
-				// 	// 	return
-				// 	// }
-
-				// 	// if (yPlacement < bounds.bottom) {
-				// 	// 	this.outOfView.set(false)
-				// 	// 	return
-				// 	// }
-				// } else {
-				// 	const xPlacement = x - bounds.left
-				// 	if (xPlacement <= 0) {
-				// 		this.outOfView.set(true)
-				// 		return
-				// 	}
-
-				// 	const yPlacement = y - bounds.top
-				// 	if (yPlacement <= 0) {
-				// 		this.outOfView.set(true)
-				// 		return
-				// 	}
-
-				// 	// if (xPlacement >= bounds.right) {
-				// 	// 	this.outOfView.set(true)
-				// 	// 	return
-				// 	// }
-
-				// 	// if (yPlacement >= bounds.bottom) {
-				// 	// 	this.outOfView.set(true)
-				// 	// 	return
-				// 	// }
-				// }
-
-				// const screenCenter = bounds.center
-				// const distance = distanceBetween(screenCenter, [x, y])
-				// if (distance > bounds.centerToCorner) {
-				// 	if (this.outOfView.get()) return
-				// 	this.outOfView.set(true)
-				// 	return
-				// }
-
-				// if (distance > bounds.centerToEdge) {
-				// 	// if (!this.outOfView.get()) return
-				// 	this.outOfView.set(true)
-				// 	return
-				// }
-
-				// if (!this.outOfView.get()) return
-				// this.outOfView.set(false)
-
-				// const screenLeft = bounds.left
-				// const screenTop = bounds.top
-				// const screenRight = bounds.right
-				// const screenBottom = bounds.bottom
-
-				// const left = x - cullbounds.x
-				// const top = y - cullbounds.y
-				// const right = x + cullbounds.x
-				// const bottom = y + cullbounds.y
-
-				// const outOfView =
-				// 	right < screenLeft || left > screenRight || bottom < screenTop || top > screenBottom
-
-				// this.outOfView.set(outOfView)
 			}, [this.transform.absolutePosition, shared.scene.bounds])
 		}
 

--- a/source/arroost/components/dom.js
+++ b/source/arroost/components/dom.js
@@ -25,6 +25,7 @@ export class Dom extends Component {
 	 * 	position?: [number, number]
 	 * 	style?: Style
 	 * 	input?: Input
+	 * 	cullBounds?: [number, number] | null
 	 * }} options
 	 */
 	constructor({
@@ -34,6 +35,7 @@ export class Dom extends Component {
 		transform = new Transform({ position }),
 		style = new Style(),
 		input,
+		cullBounds = null,
 	}) {
 		super()
 		this.id = id
@@ -41,11 +43,12 @@ export class Dom extends Component {
 		this.type = type
 		this.style = style
 		this.input = input ?? shared.scene?.input
+		this.cullBounds = this.use(cullBounds)
 
-		this.cullBoundsToCorner = this.use(() => {
-			const [x, y] = this.cullBounds.get() ?? [0, 0]
-			return distanceBetween([0, 0], [x, y])
-		})
+		// this.cullBoundsToCorner = this.use(() => {
+		// 	const [x, y] = this.cullBounds.get() ?? [0, 0]
+		// 	return distanceBetween([0, 0], [x, y])
+		// }, [this.cullBounds])
 	}
 
 	getElement() {
@@ -68,9 +71,6 @@ export class Dom extends Component {
 
 	outOfView = this.use(false)
 
-	/** @type {Signal<[number, number] | null>} */
-	cullBounds = this.use(null)
-
 	getContainer() {
 		if (this.#container) return this.#container
 
@@ -78,77 +78,167 @@ export class Dom extends Component {
 			this.type === "svg"
 				? document.createElementNS("http://www.w3.org/2000/svg", "svg")
 				: document.createElement("div")
-		container.style["position"] = "absolute"
-		container.style["width"] = "1px"
-		container.style["height"] = "1px"
-		container.style["overflow"] = "visible"
-		container.style["pointer-events"] = "none"
-		container.style["draggable"] = "false"
-		// container.style["box-sizing"] = "border-box"
-		container.style["contain"] = "size layout style content"
-		// container.style["transform-origin"] = "top left"
-		// container.style["height"] = FULL + "px"
-		// container.style["width"] = FULL + "px"
+		container.style.position = "absolute"
+		// @ts-expect-error - more performant if I just pass a number
+		container.style.width = 1
+		// @ts-expect-error
+		container.style.height = 1
+		container.style.overflow = "visible"
+		container.style.pointerEvents = "none"
+		container.style.userSelect = "none"
+		container.style.contain = "size layout style"
 
 		container.setAttribute("class", `${this.id}${this.id ? "-" : ""}container`)
 
-		this.use(
-			() => {
-				const [x, y] = this.transform.absolutePosition.get()
-				const [sx, sy] = this.transform.scale.get()
-				container.style["transform"] = `translate(${x}px, ${y}px) scale(${sx}, ${sy})`
-			},
-			{ parents: [this.transform.absolutePosition, this.transform.scale] },
-		)
+		this.use(() => {
+			const [x, y] = this.transform.absolutePosition.get()
+			// @ts-expect-error - more performant if I just pass a number
+			container.style.left = x
+			// @ts-expect-error
+			container.style.top = y
+		}, [this.transform.absolutePosition])
 
-		this.use(
-			() => {
-				const cullbounds = this.cullBounds.get()
-				if (cullbounds === null) return
+		this.use(() => {
+			const [sx, sy] = this.transform.scale.get()
+			container.style.transform = `scale(${sx}, ${sy})`
+		}, [this.transform.scale])
+
+		if (this.cullBounds.get()) {
+			this.use(() => {
 				const [x, y] = this.transform.absolutePosition.get()
 
-				const bounds = shared.scene?.bounds.get() ?? {
+				const bounds = shared.scene.bounds.get() ?? {
 					left: -Infinity,
 					top: -Infinity,
 					right: Infinity,
 					bottom: Infinity,
-					center: 0,
+					// center: [0, 0],
+					// centerToCorner: Infinity,
 				}
 
-				const screenCenter = bounds.center
-				const distance = distanceBetween(screenCenter, [x, y])
-				if (distance > bounds.centerToCorner + this.cullBoundsToCorner.get()) {
-					if (this.outOfView.get()) return
-					this.outOfView.set(true)
-					return
-				}
+				if (!this.outOfView.get()) {
+					const xPlacement = x - bounds.left
+					if (xPlacement <= 0) {
+						this.outOfView.set(true)
+						return
+					}
 
-				if (distance < bounds.centerToEdge) {
-					if (!this.outOfView.get()) return
+					const yPlacement = y - bounds.top
+					if (yPlacement <= 0) {
+						this.outOfView.set(true)
+						return
+					}
+
+					if (xPlacement >= bounds.right) {
+						this.outOfView.set(true)
+						return
+					}
+
+					if (yPlacement >= bounds.bottom) {
+						this.outOfView.set(true)
+						return
+					}
+				} else {
+					const xPlacement = x - bounds.left
+					if (xPlacement <= 0) {
+						return
+					}
+
+					const yPlacement = y - bounds.top
+					if (yPlacement <= 0) {
+						return
+					}
+
+					if (xPlacement >= bounds.right) {
+						return
+					}
+
+					if (yPlacement >= bounds.bottom) {
+						return
+					}
+
 					this.outOfView.set(false)
-					return
 				}
 
-				const screenLeft = bounds.left
-				const screenTop = bounds.top
-				const screenRight = bounds.right
-				const screenBottom = bounds.bottom
+				// if (this.outOfView.get()) {
+				// 	const xPlacement = x - bounds.left
+				// 	if (xPlacement > 0) {
+				// 		this.outOfView.set(false)
+				// 		return
+				// 	}
 
-				const left = x - cullbounds.x
-				const top = y - cullbounds.y
-				const right = x + cullbounds.x
-				const bottom = y + cullbounds.y
+				// 	const yPlacement = y - bounds.top
+				// 	if (yPlacement > 0) {
+				// 		this.outOfView.set(false)
+				// 		return
+				// 	}
 
-				const outOfView =
-					right < screenLeft || left > screenRight || bottom < screenTop || top > screenBottom
+				// 	// if (xPlacement < bounds.right) {
+				// 	// 	this.outOfView.set(false)
+				// 	// 	return
+				// 	// }
 
-				// if (outOfView === this.outOfView.get()) return
-				this.outOfView.set(outOfView)
-			},
-			{
-				parents: [this.transform.absolutePosition, shared.scene?.bounds],
-			},
-		)
+				// 	// if (yPlacement < bounds.bottom) {
+				// 	// 	this.outOfView.set(false)
+				// 	// 	return
+				// 	// }
+				// } else {
+				// 	const xPlacement = x - bounds.left
+				// 	if (xPlacement <= 0) {
+				// 		this.outOfView.set(true)
+				// 		return
+				// 	}
+
+				// 	const yPlacement = y - bounds.top
+				// 	if (yPlacement <= 0) {
+				// 		this.outOfView.set(true)
+				// 		return
+				// 	}
+
+				// 	// if (xPlacement >= bounds.right) {
+				// 	// 	this.outOfView.set(true)
+				// 	// 	return
+				// 	// }
+
+				// 	// if (yPlacement >= bounds.bottom) {
+				// 	// 	this.outOfView.set(true)
+				// 	// 	return
+				// 	// }
+				// }
+
+				// const screenCenter = bounds.center
+				// const distance = distanceBetween(screenCenter, [x, y])
+				// if (distance > bounds.centerToCorner) {
+				// 	if (this.outOfView.get()) return
+				// 	this.outOfView.set(true)
+				// 	return
+				// }
+
+				// if (distance > bounds.centerToEdge) {
+				// 	// if (!this.outOfView.get()) return
+				// 	this.outOfView.set(true)
+				// 	return
+				// }
+
+				// if (!this.outOfView.get()) return
+				// this.outOfView.set(false)
+
+				// const screenLeft = bounds.left
+				// const screenTop = bounds.top
+				// const screenRight = bounds.right
+				// const screenBottom = bounds.bottom
+
+				// const left = x - cullbounds.x
+				// const top = y - cullbounds.y
+				// const right = x + cullbounds.x
+				// const bottom = y + cullbounds.y
+
+				// const outOfView =
+				// 	right < screenLeft || left > screenRight || bottom < screenTop || top > screenBottom
+
+				// this.outOfView.set(outOfView)
+			}, [this.transform.absolutePosition, shared.scene.bounds])
+		}
 
 		this.use(
 			() => {

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -28,12 +28,12 @@ export class Creation extends Entity {
 				id: "creation",
 				type: "html",
 				input: this.input,
+				cullBounds: [HALF, HALF],
 			}),
 		))
 		const carry = (this.carry = this.attach(new Carry({ input: this.input, dom: this.dom })))
 
 		// Render elements
-		this.dom.cullBounds.set([HALF, HALF])
 		const back = (this.back = new EllipseHtml({ input: this.input }))
 		const front = (this.front = new Plus())
 		this.dom.append(this.back.dom)

--- a/source/arroost/entities/cells/dummy-creation.js
+++ b/source/arroost/entities/cells/dummy-creation.js
@@ -81,22 +81,22 @@ export class DummyCreation extends Entity {
 			return fireCell(shared.nogan, { id: this.tunnel.id })
 		})
 
-		const count = e.button === 0 ? 1 : 100
+		const count = e.button === 0 ? 1 : 10
 
 		let n = 0
 		for (let i = 0; i < count; i++) {
 			if (i % 1 === 0) n++
-			setTimeout(() => {
-				const dummy = new Dummy({
-					position: this.dom.transform.position.get(),
-				})
+			// setTimeout(() => {
+			const dummy = new Dummy({
+				position: this.dom.transform.position.get(),
+			})
 
-				shared.scene.layer.cell.append(dummy.dom)
-				const angle = Math.random() * Math.PI * 2
-				const speed = e.button === 0 ? 15 : randomBetween(10, 30)
-				const velocity = t([Math.cos(angle) * speed, Math.sin(angle) * speed])
-				dummy.carry.movement.velocity.set(velocity)
-			}, n * 1)
+			shared.scene.layer.cell.append(dummy.dom)
+			const angle = Math.random() * Math.PI * 2
+			const speed = e.button === 0 ? 15 : randomBetween(10, 30)
+			const velocity = t([Math.cos(angle) * speed, Math.sin(angle) * speed])
+			dummy.carry.movement.velocity.set(velocity)
+			// }, n * 1)
 		}
 	}
 }

--- a/source/arroost/entities/cells/dummy-creation.js
+++ b/source/arroost/entities/cells/dummy-creation.js
@@ -46,12 +46,12 @@ export class DummyCreation extends Entity {
 				id: "dummy-creation",
 				type: "html",
 				input: this.input,
+				cullBounds: [HALF, HALF],
 			}),
 		))
 		const carry = (this.carry = this.attach(new Carry({ input: this.input, dom: this.dom })))
 
 		// Render elements
-		this.dom.cullBounds.set([HALF, HALF])
 		const back = (this.back = new EllipseHtml({ input: this.input }))
 		const front = (this.front = new Ellipse())
 		this.dom.append(this.back.dom)
@@ -81,22 +81,22 @@ export class DummyCreation extends Entity {
 			return fireCell(shared.nogan, { id: this.tunnel.id })
 		})
 
-		const count = e.button === 0 ? 1 : 10
+		const count = e.button === 0 ? 1 : 100
 
 		let n = 0
 		for (let i = 0; i < count; i++) {
 			if (i % 1 === 0) n++
-			// setTimeout(() => {
-			const dummy = new Dummy({
-				position: this.dom.transform.position.get(),
-			})
+			setTimeout(() => {
+				const dummy = new Dummy({
+					position: this.dom.transform.position.get(),
+				})
 
-			shared.scene.layer.cell.append(dummy.dom)
-			const angle = Math.random() * Math.PI * 2
-			const speed = e.button === 0 ? 15 : randomBetween(10, 30)
-			const velocity = t([Math.cos(angle) * speed, Math.sin(angle) * speed])
-			dummy.carry.movement.velocity.set(velocity)
-			// }, n * 20)
+				shared.scene.layer.cell.append(dummy.dom)
+				const angle = Math.random() * Math.PI * 2
+				const speed = e.button === 0 ? 15 : randomBetween(10, 30)
+				const velocity = t([Math.cos(angle) * speed, Math.sin(angle) * speed])
+				dummy.carry.movement.velocity.set(velocity)
+			}, n * 1)
 		}
 	}
 }

--- a/source/arroost/entities/cells/dummy.js
+++ b/source/arroost/entities/cells/dummy.js
@@ -45,6 +45,7 @@ export class Dummy extends Entity {
 				type: "html",
 				input: this.input,
 				position,
+				cullBounds: [(FULL * 2) / 3, (FULL * 2) / 3],
 			}),
 		))
 
@@ -60,8 +61,6 @@ export class Dummy extends Entity {
 		this.back.dom.transform.scale.set([2 / 3, 2 / 3])
 		this.front.dom.transform.scale.set([1 / 3, 1 / 3])
 		setCellStyles({ back: back.dom, front: front.dom, input, tunnel })
-
-		this.dom.cullBounds.set([(FULL * 2) / 3, (FULL * 2) / 3])
 
 		// Nogan behaviours
 		const pointing = this.input.state("pointing")

--- a/source/arroost/entities/scene.js
+++ b/source/arroost/entities/scene.js
@@ -30,15 +30,15 @@ export class Scene extends Entity {
 		top: 0,
 		right: innerWidth,
 		bottom: innerHeight,
-		center: [innerWidth / 2, innerHeight / 2],
-		centerToCorner: distanceBetween(
-			[innerWidth / 2, innerHeight / 2],
-			[innerWidth, innerHeight],
-		),
-		centerToEdge: distanceBetween(
-			[innerWidth / 2, innerHeight / 2],
-			[innerWidth, innerHeight / 2],
-		),
+		// center: [innerWidth / 2, innerHeight / 2],
+		// centerToCorner: distanceBetween(
+		// 	[innerWidth / 2, innerHeight / 2],
+		// 	[innerWidth, innerHeight],
+		// ),
+		// centerToEdge: distanceBetween(
+		// 	[innerWidth / 2, innerHeight / 2],
+		// 	[innerWidth, innerHeight / 2],
+		// ),
 	})
 
 	constructor() {
@@ -76,26 +76,16 @@ export class Scene extends Entity {
 
 			const screenLeft = -sx / ssx
 			const screenTop = -sy / ssy
-			const screenRight = (this.width.get() - sx) / ssx
-			const screenBottom = (this.height.get() - sy) / ssy
-			const screenCenter = [
-				screenLeft + (screenRight - screenLeft) / 2,
-				screenTop + (screenBottom - screenTop) / 2,
-			]
-
-			const screenCenterToCorner = distanceBetween(screenCenter, [screenRight, screenBottom])
-			const screenCenterToEdge = distanceBetween(screenCenter, [screenRight, screenCenter.x])
+			const screenRight = this.width.get() / ssx
+			const screenBottom = this.height.get() / ssy
 
 			this.bounds.set({
 				left: screenLeft,
 				top: screenTop,
 				right: screenRight,
 				bottom: screenBottom,
-				center: screenCenter,
-				centerToCorner: screenCenterToCorner,
-				centerToEdge: screenCenterToEdge,
 			})
-		})
+		}, [this.dom.transform.position, this.dom.transform.scale, this.width, this.height])
 
 		const layer = (this.layer = {
 			cell: new Dom({ id: "cell-layer", type: "html" }),

--- a/source/arroost/entities/scene.js
+++ b/source/arroost/entities/scene.js
@@ -30,15 +30,6 @@ export class Scene extends Entity {
 		top: 0,
 		right: innerWidth,
 		bottom: innerHeight,
-		// center: [innerWidth / 2, innerHeight / 2],
-		// centerToCorner: distanceBetween(
-		// 	[innerWidth / 2, innerHeight / 2],
-		// 	[innerWidth, innerHeight],
-		// ),
-		// centerToEdge: distanceBetween(
-		// 	[innerWidth / 2, innerHeight / 2],
-		// 	[innerWidth, innerHeight / 2],
-		// ),
 	})
 
 	constructor() {


### PR DESCRIPTION
This PR speeds up (maybe) positioning of elements by splitting up scale and position into two separate signals.
It also changes some hot paths to use property names for styles instead of string keys.

This PR also fixes culling. I discovered that it was broken. I simplified it a lot.
I left culling visible at the edges of the screen so that I'll be able to see if it breaks again.
Can reimplement the pity area later on