### PR TITLE
Add cloning to the Arrow of Creation

### DIFF
--- a/documentation/manual-testing/README.md
+++ b/documentation/manual-testing/README.md
@@ -63,6 +63,18 @@ When you load, there's a circle on the screen.
 -  Does it spawn smaller circles?
 -  How does it feel?
 
+<details>
+<summary >Click here for more detailed testing.</summary>
+
+## Right-click
+
+-  Can you right-click it to make multiple circles?
+
+## Keyboard
+
+-  Can you hold ctrl and click it to make multiple circles?
+</details>
+
 ## Targeting
 
 When you spawn enough circles, a "plus" circle should spawn.

--- a/documentation/manual-testing/README.md
+++ b/documentation/manual-testing/README.md
@@ -14,55 +14,60 @@ It's really helpful if you tell me your browser and operating system too!
 
 **Note:** I'm not actively working on touch controls, so some functionality is missing (eg: pinch zooming). However, I don't want it to get completely broken! I've fixed a few crashes with it already.
 
-
 ## Camera controls
 
-* Can you move around the camera?
-* Can you zoom in and out?
-* How does it feel?
+-  Can you move around the camera?
+-  Can you zoom in and out?
+-  How does it feel?
 
 <details>
   <summary>
     Click here for more detailed testing.
   </summary>
 
-  ### All devices
-  * Can you pan by clicking-and-dragging the background?
-  
-  ### Trackpad
-  * Can you pan by sliding with two fingers?
-  * Can you pan by clicking with two fingers and dragging?
-  * Can you zoom by pinching?
-  * Can you zoom by holding ctrl/cmd and moving two fingers up and down?
+### All devices
 
-  ### Mouse
-  * Can you pan by right-clicking and dragging?
-  * Can you zoom by scrolling the wheel?
-  * Can you zoom by holding ctrl/cmd and scrolling the wheel?
+-  Can you pan by clicking-and-dragging the background?
 
-  ### Touch
-  * There are no special touch interactions yet.
+### Trackpad
+
+-  Can you pan by sliding with two fingers?
+-  Can you pan by clicking with two fingers and dragging?
+-  Can you zoom by pinching?
+-  Can you zoom by holding ctrl/cmd and moving two fingers up and down?
+
+### Mouse
+
+-  Can you pan by right-clicking and dragging?
+-  Can you zoom by scrolling the wheel?
+-  Can you zoom by holding ctrl/cmd and scrolling the wheel?
+
+### Touch
+
+-  There are no special touch interactions yet.
 </details>
 
 ## Carrying
 
 When you load, there's a circle on the screen.
-* Can you pick it up?
-* Can you throw it around?
-* How does it feel to move it around?
+
+-  Can you pick it up?
+-  Can you throw it around?
+-  How does it feel to move it around?
 
 ## Clicking
 
 When you load, there's a circle on the screen.
 
-* Can you click it?
-* Does it spawn smaller circles?
-* How does it feel?
+-  Can you click it?
+-  Does it spawn smaller circles?
+-  How does it feel?
 
 ## Targeting
 
 When you spawn enough circles, a "plus" circle should spawn.
 
-* Can you click it?
-* Does a line come out of it when you do?
-* Does the line disappear when you click again?
+-  Can you click it?
+-  Does a line come out of it when you do?
+-  Can you create something with it?
+-  Can you duplicate something with it?

--- a/source/arroost/components/dom.js
+++ b/source/arroost/components/dom.js
@@ -85,18 +85,19 @@ export class Dom extends Component {
 
 		container.setAttribute("class", `${this.id}${this.id ? "-" : ""}container`)
 
-		this.use(() => {
-			const [x, y] = this.transform.absolutePosition.get()
-			// @ts-expect-error - more performant if I just pass a number
-			container.style.left = x
-			// @ts-expect-error
-			container.style.top = y
-		}, [this.transform.absolutePosition])
+		// this.use(() => {
+		// 	const [x, y] = this.transform.absolutePosition.get()
+		// 	// @ts-expect-error - more performant if I just pass a number
+		// 	// container.style.left = x.toString() + "px"
+		// 	// @ts-expect-error
+		// 	// container.style.top = y
+		// }, [this.transform.absolutePosition])
 
 		this.use(() => {
 			const [sx, sy] = this.transform.scale.get()
-			container.style.transform = `scale(${sx}, ${sy})`
-		}, [this.transform.scale])
+			const [x, y] = this.transform.absolutePosition.get()
+			container.style.transform = `translate(${x}px,${y}px) scale(${sx}, ${sy})`
+		}, [this.transform.scale, this.transform.absolutePosition])
 
 		if (this.cullBounds.get()) {
 			this.use(() => {

--- a/source/arroost/components/input.js
+++ b/source/arroost/components/input.js
@@ -10,6 +10,8 @@ export class Input extends Component {
 		this.entity = entity
 	}
 
+	highlighted = this.use(false)
+
 	/** @type {null | InputEventHandler} */
 	pointerover = null
 

--- a/source/arroost/components/input.js
+++ b/source/arroost/components/input.js
@@ -1,9 +1,10 @@
 import { Component } from "./component.js"
 import { Entity } from "../entities/entity.js"
+import { Dom } from "./dom.js"
 
 export class Input extends Component {
 	/**
-	 * @param {Entity} entity
+	 * @param {Entity & {dom: Dom}} entity
 	 */
 	constructor(entity) {
 		super()

--- a/source/arroost/components/input.js
+++ b/source/arroost/components/input.js
@@ -12,6 +12,7 @@ export class Input extends Component {
 	}
 
 	highlighted = this.use(false)
+	targeted = this.use(false)
 
 	/** @type {null | InputEventHandler} */
 	pointerover = null

--- a/source/arroost/components/tunnel.js
+++ b/source/arroost/components/tunnel.js
@@ -67,12 +67,22 @@ export const Tunnel = class extends Component {
 		Tunnel.tunnels.delete(this.id)
 	}
 
+	/**
+	 * Run a function on the nogan - right now
+	 * @param {() => Operation[]} func
+	 * @returns {Operation[]}
+	 */
 	apply(func) {
 		const operations = func()
 		Tunnel.applyOperations(operations)
 		return operations
 	}
 
+	/**
+	 * Run a function on the nogan - at the nearest beat
+	 * @param {() => Operation[]} func
+	 * @returns {Promise<Operation[]>}
+	 */
 	async perform(func) {
 		const timeSinceLastBeat = shared.clock.time - shared.clock.lastBeatTime
 		const fractionOfBeat = timeSinceLastBeat / msPerBeat()

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -44,7 +44,7 @@ export class Creation extends Entity {
 		this.dom.append(this.front.dom)
 
 		this.arrow = new Line({ parent: this.dom.transform })
-		this.dom.append(this.arrow.dom)
+		shared.scene.layer.ghost.append(this.arrow.dom)
 
 		const pulling = this.input.state("pulling")
 		const targeting = this.input.state("targeting")
@@ -56,11 +56,19 @@ export class Creation extends Entity {
 			}
 		}, [pulling.active, targeting.active])
 
+		this.source = this.input
 		this.use(() => {
 			if (this.arrow.dom.style.visibility.get() === "hidden") return
+			this.arrow.dom.transform.setAbsolutePosition(
+				this.source.entity.dom.transform.absolutePosition.get(),
+			)
 			const pointerPosition = shared.pointer.transform.absolutePosition.get()
 			this.arrow.target.setAbsolutePosition(pointerPosition)
-		}, [shared.pointer.transform.absolutePosition, this.arrow.dom.style.visibility])
+		}, [
+			shared.pointer.transform.absolutePosition,
+			this.source.entity.dom.transform.absolutePosition,
+			this.arrow.dom.style.visibility,
+		])
 
 		// Styles!
 		front.dom.transform.scale.set([3 / 4, 3 / 4])
@@ -78,6 +86,7 @@ export class Creation extends Entity {
 
 	onClick(e) {
 		this.template = Dummy
+		this.source = this.input
 		return new Pulling()
 	}
 
@@ -92,6 +101,7 @@ export class Creation extends Entity {
 		}
 
 		this.template = DummyCreation
+		this.source = e.state.target
 		return new Pulling(this.input)
 	}
 }

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -107,6 +107,6 @@ export class Creation extends Entity {
 
 		this.template = e.state.target.entity.constructor
 		this.source = e.state.target
-		return new Pulling(this.input)
+		return new Pulling(this.input, e.state.target)
 	}
 }

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -98,6 +98,7 @@ export class Creation extends Entity {
 			})
 
 			shared.scene.layer.cell.append(dummy.dom)
+			this.tunnel.isFiring.set(true)
 			this.tunnel.perform(() => {
 				return fireCell(shared.nogan, { id: this.tunnel.id })
 			})

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -33,6 +33,7 @@ export class Creation extends Entity {
 				type: "html",
 				input: this.input,
 				cullBounds: [HALF, HALF],
+				position,
 			}),
 		))
 		const carry = (this.carry = this.attach(new Carry({ input: this.input, dom: this.dom })))
@@ -100,7 +101,7 @@ export class Creation extends Entity {
 			return
 		}
 
-		this.template = DummyCreation
+		this.template = e.state.target.entity.constructor
 		this.source = e.state.target
 		return new Pulling(this.input)
 	}

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -15,8 +15,11 @@ import { Pulling } from "../../machines/pulling.js"
 import { Line } from "../shapes/line.js"
 import { EllipseHtml } from "../shapes/ellipse-html.js"
 import { DummyCreation } from "./dummy-creation.js"
+import { Dummy } from "./dummy.js"
 
 export class Creation extends Entity {
+	pulling = this.use(false)
+
 	constructor({ id = createCell(shared.nogan, { type: "creation" }).id, position = t([0, 0]) }) {
 		super()
 		triggerCounter()
@@ -71,15 +74,24 @@ export class Creation extends Entity {
 		targeting.pointerup = this.onTargetingPointerUp.bind(this)
 	}
 
+	template = Dummy
+
 	onClick(e) {
+		this.template = Dummy
 		return new Pulling()
 	}
 
 	onTargetingPointerUp(e) {
-		const dummy = new DummyCreation({
-			position: shared.pointer.transform.absolutePosition.get(),
-		})
+		if (e.state.target === shared.scene.input) {
+			const dummy = new this.template({
+				position: shared.pointer.transform.absolutePosition.get(),
+			})
 
-		shared.scene.layer.cell.append(dummy.dom)
+			shared.scene.layer.cell.append(dummy.dom)
+			return
+		}
+
+		this.template = DummyCreation
+		return new Pulling(this.input)
 	}
 }

--- a/source/arroost/entities/cells/creation.js
+++ b/source/arroost/entities/cells/creation.js
@@ -98,6 +98,9 @@ export class Creation extends Entity {
 			})
 
 			shared.scene.layer.cell.append(dummy.dom)
+			this.tunnel.perform(() => {
+				return fireCell(shared.nogan, { id: this.tunnel.id })
+			})
 			return
 		}
 

--- a/source/arroost/entities/cells/shared.js
+++ b/source/arroost/entities/cells/shared.js
@@ -41,7 +41,7 @@ export const getCellForegroundColour = ({ tunnel, input }) => {
 	if (tunnel.isFiring.get()) {
 		return WHITE
 	}
-	if (input.is("pulling") || input.is("targeting")) {
+	if (input.is("pulling") || input.is("targeting") || input.targeted.get()) {
 		return WHITE
 	}
 	return BLACK

--- a/source/arroost/entities/cells/shared.js
+++ b/source/arroost/entities/cells/shared.js
@@ -40,7 +40,8 @@ export const setCellStyles = ({ back, front, input, tunnel }) => {
 export const getCellForegroundColour = ({ tunnel, input }) => {
 	if (tunnel.isFiring.get()) {
 		return WHITE
-	} else if (input.is("pulling") || input.is("targeting")) {
+	}
+	if (input.is("pulling") || input.is("targeting")) {
 		return WHITE
 	}
 	return BLACK

--- a/source/arroost/entities/cells/shared.js
+++ b/source/arroost/entities/cells/shared.js
@@ -47,7 +47,10 @@ export const getCellForegroundColour = ({ tunnel, input }) => {
 }
 
 export const getCellBackgroundColour = ({ input }) => {
-	if (input.is("hovering") || input.is("pulling")) {
+	if (input.is("hovering")) {
+		return GREY_SILVER
+	}
+	if (input.highlighted.get()) {
 		return GREY_SILVER
 	}
 	return GREY

--- a/source/arroost/entities/scene.js
+++ b/source/arroost/entities/scene.js
@@ -86,11 +86,11 @@ export class Scene extends Entity {
 		this.dom.append(layer.cell)
 		this.dom.append(layer.ghost)
 
-		const ghost = new Ghost()
-		layer.ghost.append(ghost.dom)
+		// const ghost = new Ghost()
+		// layer.ghost.append(ghost.dom)
 
-		const counter = new Counter()
-		layer.ghost.append(counter.dom)
+		// const counter = new Counter()
+		// layer.ghost.append(counter.dom)
 
 		requestAnimationFrame(() => replenishUnlocks())
 	}

--- a/source/arroost/entities/shapes/line.js
+++ b/source/arroost/entities/shapes/line.js
@@ -17,7 +17,7 @@ export class Line extends Entity {
 	constructor({ input, parent = Transform.Root } = {}) {
 		super()
 		this.dom = this.attach(new Dom({ type: "svg", id: "line", input }))
-		this.target = this.attach(new Transform({ parent }))
+		this.target = this.attach(new Transform({ parent: this.dom.transform }))
 		this.dom.style.stroke.set(WHITE.toString())
 		this.dom.style.strokeWidth.set(QUARTER)
 		this.dom.render = () => this.render()

--- a/source/arroost/entities/unlock.js
+++ b/source/arroost/entities/unlock.js
@@ -11,7 +11,7 @@ export const unlocks = {
 		create: (arg) => new DummyCreation(arg),
 	},
 	"creation": {
-		unlocked: false,
+		unlocked: true,
 		remaining: 5,
 		create: (arg) => new Creation(arg),
 	},

--- a/source/arroost/machines/pulling.js
+++ b/source/arroost/machines/pulling.js
@@ -10,14 +10,14 @@ export class Pulling extends InputState {
 	/**
 	 * @param {Input} [input]
 	 */
-	constructor(input = undefined) {
+	constructor(input = undefined, target = undefined) {
 		super(input)
-		this.target = this.input
+		this.target = target ?? this.input
 		this.target.highlighted.set(true)
 	}
 
 	pointerdown() {
-		this.target.highlighted.set(false)
+		// this.target.highlighted.set(false)
 		return new Targeting({ input: this.input, target: this.target })
 	}
 

--- a/source/arroost/machines/pulling.js
+++ b/source/arroost/machines/pulling.js
@@ -1,10 +1,32 @@
+import { use } from "../../../libraries/habitat-import.js"
+import { shared } from "../../main.js"
+import { Input } from "../components/input.js"
 import { Hovering, InputState } from "./input.js"
 import { Targeting } from "./targeting.js"
 
 export class Pulling extends InputState {
 	name = "pulling"
 
+	/**
+	 * @param {Input} [input]
+	 */
+	constructor(input = undefined) {
+		super(input)
+		this.target = this.input
+		this.target.highlighted.set(true)
+	}
+
 	pointerdown() {
-		return new Targeting(this.input)
+		this.target.highlighted.set(false)
+		return new Targeting({ input: this.input, target: this.target })
+	}
+
+	pointerover() {
+		const oldTarget = this.target
+		const newTarget = shared.hovering.input.get()
+		if (oldTarget === newTarget) return
+		oldTarget.highlighted.set(false)
+		this.target = newTarget
+		newTarget.highlighted.set(true)
 	}
 }

--- a/source/arroost/machines/targeting.js
+++ b/source/arroost/machines/targeting.js
@@ -3,6 +3,11 @@ import { Hovering, InputState } from "./input.js"
 export class Targeting extends InputState {
 	name = "targeting"
 
+	constructor({ input, target }) {
+		super(input)
+		this.target = target
+	}
+
 	pointerup() {
 		return new Hovering()
 	}

--- a/source/main.js
+++ b/source/main.js
@@ -73,6 +73,7 @@ shared.hovering = hover.state.get()
 // The input machine handles the core interaction for entities
 // ie: hovering, pointing, dragging
 const input = new Machine(new InputMachine())
+shared.input = input
 
 registerWheel()
 registerMachine(hover)


### PR DESCRIPTION
This PR adds new functionality to the Arrow of Creation. It can now clone other arrows. And it 'chain' from one cell to another. They should all light up when this happens.

Still to do:
- Show arrows along all parts of the chain.
- Show an arrow instead of a line. 