### PR TITLE
Fix memo causing some instant pulses to not propogate

### DIFF
--- a/source/nogan/nogan.js
+++ b/source/nogan/nogan.js
@@ -1276,7 +1276,6 @@ export const refresh = (
 				colour,
 				past,
 				future,
-				// TODO: fix memo here. it was for perf but was causing issue
 				memo,
 			})
 			operations.push(...peak.operations)

--- a/source/nogan/nogan.js
+++ b/source/nogan/nogan.js
@@ -1267,7 +1267,7 @@ export const refresh = (
 	{ snapshot = getClone(nogan), past = [], future = [], operate = true, filter } = {},
 ) => {
 	const operations = []
-	const memo = new GetPeakMemo()
+	let memo = new GetPeakMemo()
 	for (const id of iterateCellIds(snapshot)) {
 		if (filter && !filter(id)) continue
 		for (const colour of PULSE_COLOURS) {
@@ -1287,6 +1287,10 @@ export const refresh = (
 				pulse: peak.pulse,
 				propogate: false,
 			})
+
+			// If we've changed the nogan, we need to refresh the cache
+			// (as things might be different now)
+			memo = new GetPeakMemo()
 			operations.push(...firedOperations)
 		}
 	}

--- a/source/nogan/nogan.test.js
+++ b/source/nogan/nogan.test.js
@@ -1654,3 +1654,18 @@ describe.skip("destruction", () => {
 		assertEquals(recording.type, "slot")
 	})
 })
+
+describe("memoisation", () => {
+	it("spreads instant fires correctly", () => {
+		const nogan = createNogan()
+		const slot1 = createCell(nogan, { type: "slot" })
+		const slot2 = createCell(nogan, { type: "slot" })
+		const slot3 = createCell(nogan, { type: "slot" })
+		createWire(nogan, { source: slot1.id, target: slot2.id })
+		createWire(nogan, { source: slot2.id, target: slot3.id })
+		createWire(nogan, { source: slot3.id, target: slot1.id })
+
+		const operations = fireCell(nogan, { id: slot1.id })
+		assertEquals(operations.length, 3) // Should have fired all three slots
+	})
+})


### PR DESCRIPTION
It was happening because we were sometimes 'sneakily' firing cells during a refresh loop. ie: We weren't propogating those firings. I think this is so that it doesn't double up certain operations (some tests break if you propogate). This seems really naughty.......... I'm pretty sure this is also causing some other issues........

*But let's just focus on one problem at a time.*

The problem here was that we were using a cache at the start of the loop, which was then getting 'out-of-date' when we did one of these 'sneaky' fires. When we do a sneaky fire, we just refresh the cache now. We could probably do this more selectively (eg: only refresh a certain part of the cache) but that seems fine for now.

Fixes #209 
