### PR TITLE
Fix deleting wire through arrow of colour (#276)

### DIFF
--- a/source/arroost/entities/arrows/destruction.js
+++ b/source/arroost/entities/arrows/destruction.js
@@ -146,7 +146,7 @@ export class ArrowOfDestruction extends Entity {
 			}
 			const cell = getCell(shared.nogan, id)
 			if (!cell) return []
-			if (cell.type === "timing") {
+			if (cell.type === "timing" || cell.type === "colour") {
 				const wire = getWire(shared.nogan, cell.wire)
 				return deleteWire(shared.nogan, wire.id)
 			}


### PR DESCRIPTION
This presumably fixes #276 by removing the entire wire instead of only the cell for the `ArrowOfColour`, the code was already there for the `ArrowOfTiming`.  Not tested.