### PR TITLE
Remove three @ts-expect-errors for mapping types

### DIFF
--- a/source/arroost/components/tunnel.js
+++ b/source/arroost/components/tunnel.js
@@ -66,11 +66,12 @@ export class Tunnel extends Component {
 	}
 
 	/**
-	 * @param {Operation} operation
+	 * Typing based on: https://github.com/microsoft/TypeScript/pull/47109
+	 * @template {OperationType} key
+	 * @param {OperationMap<key>} operation
 	 */
 	static applyOperation(operation) {
 		const tunnelFunction = TUNNELS[operation.type]
-		// @ts-expect-error: freaks out
 		tunnelFunction(operation)
 	}
 

--- a/source/arroost/entities/arrows/connection.js
+++ b/source/arroost/entities/arrows/connection.js
@@ -170,6 +170,7 @@ export class ArrowOfConnection extends Entity {
 		const entity = target.entity
 		const dummyWire = new ArrowOfTime({
 			// @ts-expect-error - Don't know why it isn't figuring out its type here.
+			// See: https://github.com/microsoft/TypeScript/issues/50651#issuecomment-1476795579
 			source: sourceEntity,
 			target: entity,
 			timing: ArrowOfConnection.timing,

--- a/source/arroost/entities/arrows/reality.js
+++ b/source/arroost/entities/arrows/reality.js
@@ -97,7 +97,7 @@ export class ArrowOfReality extends Entity {
 			const operations = []
 			for (const key in fire) {
 				if (fire[key] === null) continue
-				// @ts-expect-error: cant be fucked to type Fire correctly
+				// @ts-expect-error: `Fire` is typed correctly, but `fire` may theoretically be a subtype with additional keys
 				operations.push(...fireCell(shared.nogan, { id, colour: key }))
 			}
 			return operations

--- a/source/nogan/declare.d.ts
+++ b/source/nogan/declare.d.ts
@@ -95,31 +95,43 @@ declare type Behave<T extends Pulse> = ({
 	peak: SuccessPeak & { pulse: T }
 }) => Peak
 
-declare type BehaviourMap = {
-	[key in PulseType]: Behave<Extract<Pulse, { type: key }>>
+declare type PulseMap<key extends PulseType = PulseType> = {
+	[P in key]: { type: P } & Omit<Extract<Pulse, { type: P }>, "type">
+}[key]
+
+declare type BehaviourMap<key extends PulseType = PulseType> = {
+	[P in key]: Behave<PulseMap<P>>
 }
 
 //===========//
 // Operation //
 //===========//
+// Based on: https://github.com/microsoft/TypeScript/pull/47109
 declare type Operation = ReportOperation | InstructionOperation
-declare type Operate<T extends Operation> = (nogan: Nogan, operation: T) => Operation[]
-declare type OperationMap = {
-	[key in OperationType]: Operate<Extract<Operation, { type: key }>>
+declare type OperationMap<key extends OperationType = OperationType> = {
+	[P in key]: { type: P } & Omit<Extract<Operation, { type: P }>, "type">
+}[key]
+
+declare type Operate<key extends OperationType> = (nogan: Nogan, operation: OperationMap<key>) => Operation[]
+declare type OperateMap<key extends OperationType = OperationType> = {
+	[P in key]: Operate<P>
 }
 
-declare type TunnelFunction<T extends Operation> = (operation: T) => void
-declare type TunnelMap = {
-	[key in OperationType]: TunnelFunction<Extract<Operation, { type: key }>>
+declare type TunnelFunction<key extends OperationType = OperationType> = (operation: OperationMap<key>) => void
+declare type TunnelMap<key extends OperationType = OperationType> = {
+	[P in key]: TunnelFunction<P>
 }
 
 //======//
 // Fire //
 //======//
+// declare type Fire = {
+// 	red: Pulse | null
+// 	green: Pulse | null
+// 	blue: Pulse | null
+// }
 declare type Fire = {
-	red: Pulse | null
-	green: Pulse | null
-	blue: Pulse | null
+	[key in PulseColour]: Pulse | null
 }
 
 //=======//

--- a/source/nogan/nogan.js
+++ b/source/nogan/nogan.js
@@ -1603,13 +1603,12 @@ const getBehavedPeak = ({ nogan, source, target, previous, peak }) => {
 }
 
 /**
- * @template {Pulse} T
- * @param {T} pulse
- * @returns {Behave<T>}
+ * @template {PulseType} T
+ * @param {PulseMap<T>} pulse
+ * @returns {Behave<PulseMap<T>>}
  */
 export const getBehave = (pulse) => {
 	const behave = BEHAVIOURS[pulse.type]
-	// @ts-expect-error
 	return behave
 }
 
@@ -1721,12 +1720,11 @@ export const applyOperations = (nogan, { operations }) => {
 }
 
 /**
- * @template {Operation} T
- * @param {T} operation
+ * @template {OperationType} T
+ * @param {OperationMap<T>} operation
  * @returns {Operate<T>}
  */
 export const getOperate = (operation) => {
 	const operate = OPERATIONS[operation.type]
-	// @ts-expect-error
 	return operate
 }

--- a/source/nogan/operate.js
+++ b/source/nogan/operate.js
@@ -1,6 +1,6 @@
 import { getCell, getWire, modifyCell, modifyWire, unfireCell } from "./nogan.js"
 
-/** @type {OperationMap} */
+/** @type {OperateMap} */
 export const OPERATIONS = {
 	/** Modify a cell */
 	modifyCell(nogan, { id, template }) {


### PR DESCRIPTION
This does some hacky things to get inference that works for the mapping types.  Based on: https://github.com/microsoft/TypeScript/pull/47109

Also adds two comments where the expect error cannot reasonably be removed (as far as I can see).

Experiment with it here:
https://www.typescriptlang.org/play?ts=5.3.3#code/C4TwDgpgBAYglgJwgEwPKQQQ2HA9gOygF4oBvKUSALigCIAzRFWgGigGMIAbLm-AVwC2AIwgIoAXwBQlaAFlcANxTox2PIRLlZNWoKXM2nHnyGiEbMLgDOcHARoBtASLFsX5gLqSZ4aKqx7TVgmNAx1AigAHygFZTC1IKlkgHoUij8oAIjg8kYkZBpUQTsAHngC7KC2WllaAD42fXiikuBSuJVw6ro6+skAbl9ILO6NABVMkiqNR1q-Wk9k2VHEjTlMMFKAaSgIAA9gCHxka1XAib9+rShHAAUoOEJtzxpSKShPjOooO5YpCRQABkWTapQAoocsOx2jMCGxSDpfhJGr0FvUAY4XkNhtAYPx8DD1psdntDsdTuccpNINcyB8vvdHs9XlAABS4MYOKlBDZbO71ACUxH6ilwcGQAOS7AI1mAUHoBKJBD5NHxhN5JLh+BpEDp7y+CtCNDZ+RQAH1OWtuRUutb8IKaGKJSL6YbDWbkJaufgAHTGLgMz4Sf6G5ooE3hr1Wi7czoJWMOp3i5Cug3uz5R732-3cQMZzMGaM+31WWxJQ3SaRSRUajRQTZgLggbWkg5HE5nbW6+ocn1FH18nZC5Mu9OfGX4OVQfbEKAxnK+2RBjiy+W19hzjeasCOfZLD1Kvv2wVSoA

I had a lot of fun trying to understand what's going on with this solution, it's bizarre that it works.

For some reason, the explicit `{type: …} & Omit<…, "type">` is necessary. I still don't know why.