### PR TITLE
Change color to indicate mic level while recording

### DIFF
--- a/source/arroost/entities/arrows/recording.js
+++ b/source/arroost/entities/arrows/recording.js
@@ -41,7 +41,7 @@ export class ArrowOfRecording extends Entity {
 	static recordings = new SharedResource()
 
 	recorder = new Tone.Recorder()
-	meter = new Tone.Meter()
+	meter = new Tone.Meter(0.9)
 	microphone = new Tone.UserMedia().connect(this.recorder).connect(this.meter)
 	players = new Set()
 

--- a/source/arroost/entities/arrows/recording.js
+++ b/source/arroost/entities/arrows/recording.js
@@ -194,7 +194,8 @@ export class ArrowOfRecording extends Entity {
 		const minDecibels = -50, maxDecibels = 0
 		const clamped = Math.max(minDecibels, Math.min(this.meter.getValue(), maxDecibels))
 		const frac = (clamped - minDecibels) / (maxDecibels - minDecibels)
-		const color = new Colour(...lerp([BLACK, RED], frac).map(Math.round))
+		const fracWeight = 0.5
+		const color = new Colour(...lerp([BLACK, RED], (1 - fracWeight) + frac * fracWeight).map(Math.round))
 		this.front.dom.style.fill.set(color.toString())
 	}
 


### PR DESCRIPTION
This PR provides some visual feedback to indicate whether the mic is working! :microphone: :100: 

Note that this avoids showing [sound waves](https://www.todepond.com/report/arroost/#:~:text=sound%20waves); it just shows the mic's current level while recording.

Demo with mic working & not (unmute to hear my beautiful voice):

https://github.com/user-attachments/assets/0d741c44-2920-460f-a4ec-e9d7157085d4

Inspired by [this moment](https://www.youtube.com/live/4GOeYylCMJI?si=llDb8IVtPVJXkJF2&t=12992) at LIVE (in which it wasn't clear that there were mic issues until *after* recording) and ensuing discussion.